### PR TITLE
Improve Octane compatibility

### DIFF
--- a/src/PaymobServiceProvider.php
+++ b/src/PaymobServiceProvider.php
@@ -22,8 +22,14 @@ class PaymobServiceProvider extends ServiceProvider
             'payment'
         );
 
-	    $this->app->singleton(Paymob::class, function () {
-		    return new Paymob(config('payment.paymob.api_key'));
-	    });
+        if (method_exists($this->app, 'scoped')) {
+            $this->app->scoped(Paymob::class, function () {
+                return new Paymob(config('payment.paymob.api_key'));
+            });
+        } else {
+            $this->app->bind(Paymob::class, function () {
+                return new Paymob(config('payment.paymob.api_key'));
+            });
+        }
     }
 }


### PR DESCRIPTION
## Summary
- avoid leaking Paymob instances across requests
- bind Paymob class to the service container using a scoped/bind approach

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f5ecbeb908332b3110d706dd72c8a