### PR TITLE
Remove caching from authentication

### DIFF
--- a/src/Paymob.php
+++ b/src/Paymob.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Zeal\Paymob;
 
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Zeal\Paymob\Models\PaymentKey;
 use Zeal\Paymob\Models\PaymentOrder;
@@ -217,14 +216,7 @@ final class Paymob
     private function ensureAuthToken(): void
     {
         if (!$this->authToken) {
-            $this->authToken = Cache::remember($this->getCacheKey(), 300, function () {
-                return $this->authenticate();
-            });
+            $this->authToken = $this->authenticate();
         }
-    }
-
-    private function getCacheKey(): string
-    {
-        return 'paymob_auth_token_' . md5($this->apiKey);
     }
 }


### PR DESCRIPTION
## Summary
- remove Cache facade usage from authentication path in `Paymob`
- directly call `authenticate()` whenever the service lacks an auth token

## Testing
- `php -l src/Paymob.php` *(fails: `php` not installed)*
- `composer --version` *(fails: `composer` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684ed172526883319ae75c8e0e42e272