### PR TITLE
Add logging to authentication response

### DIFF
--- a/src/Response/AuthenticationResponse.php
+++ b/src/Response/AuthenticationResponse.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Zeal\Paymob\Response;
 
+use App\Models\Log;
 use Zeal\Paymob\Exceptions\InvalidAuthenticationException;
 use Illuminate\Http\Client\Response;
 
@@ -29,7 +30,12 @@ final class AuthenticationResponse
     {
         $this->response = $response;
 
-        $this->body = (object)json_decode((string) $response->getBody());
+        $this->body = (object) json_decode((string) $response->getBody());
+
+        Log::create([
+            'key' => 'paymob_authentication_response',
+            'payload' => json_encode($this->body),
+        ]);
 
         $this->handleResponseExceptions();
     }


### PR DESCRIPTION
## Summary
- log the authentication response for debugging purposes

## Testing
- `php -l src/Response/AuthenticationResponse.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684ef0d8c3d08331a33720e840661e11