### PR TITLE
Remove logs and extend auth token cache

### DIFF
--- a/src/Paymob.php
+++ b/src/Paymob.php
@@ -6,7 +6,6 @@ namespace Zeal\Paymob;
 
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
-use App\Models\Log;
 use Zeal\Paymob\Models\PaymentKey;
 use Zeal\Paymob\Models\PaymentOrder;
 use Zeal\Paymob\Response\AuthenticationResponse;
@@ -207,11 +206,6 @@ final class Paymob
 
     private function authenticate(): string
     {
-        Log::create([
-            'key' => 'paymob_authentication_request',
-            'payload' => json_encode(['api_key' => $this->apiKey]),
-        ]);
-
         $response = Http::withHeaders(['Content-Type' => 'application/json'])
             ->post($this->api . 'api/auth/tokens', ['api_key' => $this->apiKey]);
 
@@ -223,7 +217,7 @@ final class Paymob
     private function ensureAuthToken(): void
     {
         if (!$this->authToken) {
-            $this->authToken = Cache::remember($this->getCacheKey(), 300, function () {
+            $this->authToken = Cache::remember($this->getCacheKey(), 3600, function () {
                 return $this->authenticate();
             });
         }

--- a/src/Response/AuthenticationResponse.php
+++ b/src/Response/AuthenticationResponse.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Zeal\Paymob\Response;
 
-use App\Models\Log;
 use Zeal\Paymob\Exceptions\InvalidAuthenticationException;
 use Illuminate\Http\Client\Response;
 
@@ -31,11 +30,6 @@ final class AuthenticationResponse
         $this->response = $response;
 
         $this->body = (object) json_decode((string) $response->getBody());
-
-        Log::create([
-            'key' => 'paymob_authentication_response',
-            'payload' => json_encode($this->body),
-        ]);
 
         $this->handleResponseExceptions();
     }


### PR DESCRIPTION
## Summary
- remove Log usages
- cache auth token for an hour

## Testing
- `composer install` *(fails: composer not found)*
- `vendor/bin/phpcs -v` *(fails: no such file or directory)*
- `vendor/bin/phpunit --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_685015f28384833192aca64e47e8c36a