### PR TITLE
Adjust auth token cache time to 45 minutes

### DIFF
--- a/src/Paymob.php
+++ b/src/Paymob.php
@@ -217,7 +217,7 @@ final class Paymob
     private function ensureAuthToken(): void
     {
         if (!$this->authToken) {
-            $this->authToken = Cache::remember($this->getCacheKey(), 3600, function () {
+            $this->authToken = Cache::remember($this->getCacheKey(), 2700, function () {
                 return $this->authenticate();
             });
         }


### PR DESCRIPTION
## Summary
- reduce the auth token cache period from 1 hour to 45 minutes

## Testing
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685035c86d088331a135d2e8129bb312